### PR TITLE
[FEAT] 답변 공감 기능

### DIFF
--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
@@ -16,14 +16,14 @@ class AnswerController(
         private val answerService: AnswerService
 ) {
     @Auth
-    @Operation(summary = "[인증] 답변 조회")
+    @Operation(summary = "[인증] 질문 답변 조회")
     @GetMapping("/v1/answer/{answerId}")
     fun findAnswerInfoById(@PathVariable answerId: Long): ApiResponse<AnswerInfoResponse> {
         return ApiResponse.success(answerService.findAnswerInfoById(answerId))
     }
 
     @Auth
-    @Operation(summary = "[인증] 답변 공감")
+    @Operation(summary = "[인증] 질문 답변 공감")
     @PostMapping("/v1/answer/like/{answerId}")
     fun likeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
         answerService.createLike(memberId, answerId)
@@ -31,7 +31,7 @@ class AnswerController(
     }
 
     @Auth
-    @Operation(summary = "[인증] 답변 공감 취소")
+    @Operation(summary = "[인증] 질문 답변 공감 취소")
     @DeleteMapping("/v1/answer/like/{answerId}")
     fun dislikeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
         answerService.deleteLike(memberId, answerId)

--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
@@ -6,10 +6,7 @@ import com.th.plu.api.service.answer.AnswerService
 import com.th.plu.common.dto.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "Answer")
 @RestController
@@ -22,5 +19,12 @@ class AnswerController(
     @GetMapping("/v1/answer/{answerId}")
     fun findAnswerById(@PathVariable answerId: Long): ApiResponse<AnswerInfoResponse> {
         return ApiResponse.success(answerService.findAnswerInfoById(answerId))
+    }
+
+    @Operation(summary = "답변 좋아요")
+    @PostMapping("/v1/answer/like/{answerId}")
+    fun likeAnswer(@PathVariable answerId: Long): ApiResponse<Any> {
+        answerService.likeAnswerById(1L, answerId)
+        return ApiResponse.success()
     }
 }

--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
@@ -16,14 +16,14 @@ class AnswerController(
         private val answerService: AnswerService
 ) {
     @Auth
-    @Operation(summary = "답변 조회")
+    @Operation(summary = "[인증] 답변 조회")
     @GetMapping("/v1/answer/{answerId}")
-    fun findAnswerById(@PathVariable answerId: Long): ApiResponse<AnswerInfoResponse> {
+    fun findAnswerInfoById(@PathVariable answerId: Long): ApiResponse<AnswerInfoResponse> {
         return ApiResponse.success(answerService.findAnswerInfoById(answerId))
     }
 
     @Auth
-    @Operation(summary = "답변 공감")
+    @Operation(summary = "[인증] 답변 공감")
     @PostMapping("/v1/answer/like/{answerId}")
     fun likeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
         answerService.likeAnswerById(memberId, answerId)
@@ -31,7 +31,7 @@ class AnswerController(
     }
 
     @Auth
-    @Operation(summary = "답변 좋아요")
+    @Operation(summary = "[인증] 답변 공감 취소")
     @DeleteMapping("/v1/answer/like/{answerId}")
     fun dislikeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
         answerService.dislikeAnswerById(memberId, answerId)

--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
@@ -1,6 +1,7 @@
 package com.th.plu.api.controller.answer
 
 import com.th.plu.api.config.interceptor.Auth
+import com.th.plu.api.config.resolver.MemberId
 import com.th.plu.api.controller.answer.dto.response.AnswerInfoResponse
 import com.th.plu.api.service.answer.AnswerService
 import com.th.plu.common.dto.response.ApiResponse
@@ -21,10 +22,19 @@ class AnswerController(
         return ApiResponse.success(answerService.findAnswerInfoById(answerId))
     }
 
-    @Operation(summary = "답변 좋아요")
+    @Auth
+    @Operation(summary = "답변 공감")
     @PostMapping("/v1/answer/like/{answerId}")
-    fun likeAnswer(@PathVariable answerId: Long): ApiResponse<Any> {
-        answerService.likeAnswerById(1L, answerId)
+    fun likeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
+        answerService.likeAnswerById(memberId, answerId)
+        return ApiResponse.success()
+    }
+
+    @Auth
+    @Operation(summary = "답변 좋아요")
+    @DeleteMapping("/v1/answer/like/{answerId}")
+    fun dislikeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
+        answerService.dislikeAnswerById(memberId, answerId)
         return ApiResponse.success()
     }
 }

--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/AnswerController.kt
@@ -26,7 +26,7 @@ class AnswerController(
     @Operation(summary = "[인증] 답변 공감")
     @PostMapping("/v1/answer/like/{answerId}")
     fun likeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
-        answerService.likeAnswerById(memberId, answerId)
+        answerService.createLike(memberId, answerId)
         return ApiResponse.success()
     }
 
@@ -34,7 +34,7 @@ class AnswerController(
     @Operation(summary = "[인증] 답변 공감 취소")
     @DeleteMapping("/v1/answer/like/{answerId}")
     fun dislikeAnswer(@PathVariable answerId: Long, @MemberId memberId: Long): ApiResponse<Any> {
-        answerService.dislikeAnswerById(memberId, answerId)
+        answerService.deleteLike(memberId, answerId)
         return ApiResponse.success()
     }
 }

--- a/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/dto/response/AnswerInfoResponse.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/controller/answer/dto/response/AnswerInfoResponse.kt
@@ -4,7 +4,7 @@ import com.th.plu.domain.domain.answer.Answer
 import com.th.plu.domain.domain.question.Question
 import java.time.LocalDateTime
 
-class AnswerInfoResponse(
+data class AnswerInfoResponse(
         val questionDate: LocalDateTime,
         val questionTitle: String,
         val answer: String,

--- a/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
@@ -1,8 +1,12 @@
 package com.th.plu.api.service.answer
 
 import com.th.plu.api.controller.answer.dto.response.AnswerInfoResponse
+import com.th.plu.api.service.like.LikeValidator
 import com.th.plu.domain.domain.answer.explorer.AnswerExplorer
 import com.th.plu.domain.domain.answer.explorer.QuestionExplorer
+import com.th.plu.domain.domain.like.Like
+import com.th.plu.domain.domain.like.repository.LikeRepository
+import com.th.plu.domain.domain.member.explorer.MemberExplorer
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional
 class AnswerService(
         private val questionExplorer: QuestionExplorer,
         private val answerExplorer: AnswerExplorer,
+        private val likeRepository: LikeRepository,
+        private val likeValidator: LikeValidator,
+        private val memberExplorer: MemberExplorer
 ) {
     @Transactional(readOnly = true)
     fun findAnswerInfoById(id: Long): AnswerInfoResponse {
@@ -17,5 +24,15 @@ class AnswerService(
         val question = questionExplorer.findQuestionById(answer.getQuestionId())
 
         return AnswerInfoResponse.of(question, answer)
+    }
+
+    @Transactional
+    fun likeAnswerById(memberId: Long, answerId: Long) {
+        val member = memberExplorer.findMemberById(memberId)
+        val answer = answerExplorer.findAnswerById(answerId)
+        val question = questionExplorer.findQuestionById(answer.getQuestionId())
+
+        likeValidator.validateNotExistLike(member = member, answer = answer, question = question)
+        likeRepository.save(Like.newInstance(answer = answer, member = member, question = question))
     }
 }

--- a/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
@@ -26,7 +26,7 @@ class AnswerService(
     }
 
     @Transactional
-    fun likeAnswerById(memberId: Long, answerId: Long) {
+    fun createLike(memberId: Long, answerId: Long) {
         val member = memberExplorer.findMemberById(memberId)
         val answer = answerExplorer.findAnswerById(answerId)
 
@@ -35,7 +35,7 @@ class AnswerService(
     }
 
     @Transactional
-    fun dislikeAnswerById(memberId: Long, answerId: Long) {
+    fun deleteLike(memberId: Long, answerId: Long) {
         val member = memberExplorer.findMemberById(memberId)
         val answer = answerExplorer.findAnswerById(answerId)
 

--- a/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/service/answer/AnswerService.kt
@@ -3,8 +3,8 @@ package com.th.plu.api.service.answer
 import com.th.plu.api.controller.answer.dto.response.AnswerInfoResponse
 import com.th.plu.api.service.like.LikeValidator
 import com.th.plu.domain.domain.answer.explorer.AnswerExplorer
-import com.th.plu.domain.domain.answer.explorer.QuestionExplorer
 import com.th.plu.domain.domain.like.Like
+import com.th.plu.domain.domain.like.explorer.LikeExplorer
 import com.th.plu.domain.domain.like.repository.LikeRepository
 import com.th.plu.domain.domain.member.explorer.MemberExplorer
 import org.springframework.stereotype.Service
@@ -12,27 +12,34 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AnswerService(
-        private val questionExplorer: QuestionExplorer,
         private val answerExplorer: AnswerExplorer,
         private val likeRepository: LikeRepository,
+        private val likeExplorer: LikeExplorer,
         private val likeValidator: LikeValidator,
         private val memberExplorer: MemberExplorer
 ) {
     @Transactional(readOnly = true)
     fun findAnswerInfoById(id: Long): AnswerInfoResponse {
         val answer = answerExplorer.findAnswerById(id)
-        val question = questionExplorer.findQuestionById(answer.getQuestionId())
 
-        return AnswerInfoResponse.of(question, answer)
+        return AnswerInfoResponse.of(answer.question, answer)
     }
 
     @Transactional
     fun likeAnswerById(memberId: Long, answerId: Long) {
         val member = memberExplorer.findMemberById(memberId)
         val answer = answerExplorer.findAnswerById(answerId)
-        val question = questionExplorer.findQuestionById(answer.getQuestionId())
 
-        likeValidator.validateNotExistLike(member = member, answer = answer, question = question)
-        likeRepository.save(Like.newInstance(answer = answer, member = member, question = question))
+        likeValidator.validateNotExistLike(member = member, answer = answer, question = answer.question)
+        likeRepository.save(Like.newInstance(answer = answer, member = member, question = answer.question))
+    }
+
+    @Transactional
+    fun dislikeAnswerById(memberId: Long, answerId: Long) {
+        val member = memberExplorer.findMemberById(memberId)
+        val answer = answerExplorer.findAnswerById(answerId)
+
+        val like = likeExplorer.findLikeByMemberAndAnswerAndQuestion(member = member, answer = answer, question = answer.question)
+        likeRepository.delete(like)
     }
 }

--- a/plu-api/src/main/kotlin/com/th/plu/api/service/like/LikeValidator.kt
+++ b/plu-api/src/main/kotlin/com/th/plu/api/service/like/LikeValidator.kt
@@ -1,0 +1,20 @@
+package com.th.plu.api.service.like
+
+import com.th.plu.common.exception.code.ErrorCode
+import com.th.plu.common.exception.model.ConflictException
+import com.th.plu.domain.domain.answer.Answer
+import com.th.plu.domain.domain.like.repository.LikeRepository
+import com.th.plu.domain.domain.member.Member
+import com.th.plu.domain.domain.question.Question
+import org.springframework.stereotype.Component
+
+@Component
+class LikeValidator(
+        private val likeRepository: LikeRepository
+) {
+    fun validateNotExistLike(member: Member, answer: Answer, question: Question) {
+        if (likeRepository.existByMemberAndAnswerAndQuestion(member = member, answer = answer, question = question)) {
+            throw ConflictException(ErrorCode.CONFLICT_LIKE_EXCEPTION, "이미 회원(ID: ${member.id}은 해당 답변(ID: ${answer.id})에 대한 공감이 되어있습니다.")
+        }
+    }
+}

--- a/plu-common/src/main/kotlin/com/th/plu/common/exception/code/ErrorCode.kt
+++ b/plu-common/src/main/kotlin/com/th/plu/common/exception/code/ErrorCode.kt
@@ -23,6 +23,7 @@ enum class ErrorCode(val code: String, val message: String) {
     NOT_FOUND_MEMBER_EXCEPTION("N002", "탈퇴했거나 존재하지 않는 회원입니다."),
     NOT_FOUND_ANSWER_EXCEPTION("N003", "존재하지 않는 답변입니다."),
     NOT_FOUND_QUESTION_EXCEPTION("N004", "존재하지 않는 질문입니다."),
+    NOT_FOUND_LIKE_EXCEPTION("N005", "존재하지 않는 공감 정보입니다."),
     NOT_FOUND_ARTICLE_CONTENT_EXCEPTION("N003", "아티클의 컨텐츠가 존재하지 않습니다."),
     NOT_FOUND_CHALLENGE_EXCEPTION("N004", "존재하지 않는 챌린지입니다."),
     NOT_FOUND_ARTICLE_EXCEPTION("N005", "삭제되었거나 존재하지 않는 아티클입니다."),
@@ -32,6 +33,7 @@ enum class ErrorCode(val code: String, val message: String) {
     // Conflict Exception
     CONFLICT_EXCEPTION("C001", "이미 존재합니다."),
     CONFLICT_MEMBER_EXCEPTION("C002", "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요."),
+    CONFLICT_LIKE_EXCEPTION("C003", "이미 해당 답변에 대한 공감이 되어있습니다."),
     CONFLICT_BOOKMARK_EXCEPTION("C003", "요청과 동일한 북마크 상태 입니다."),
 
     // Internal Server Exception

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/answer/Answer.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/answer/Answer.kt
@@ -44,8 +44,4 @@ class Answer(
     fun getLikeCount(): Int {
         return likes.size
     }
-
-    fun getQuestionId(): Long {
-        return question.id!!
-    }
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/Like.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/Like.kt
@@ -15,15 +15,15 @@ class Like(
         @Column(name = "like_id")
         var id: Long? = null,
 
-        @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+        @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "member_id", nullable = false)
         var member: Member,
 
-        @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+        @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "answer_id", nullable = false)
         var answer: Answer,
 
-        @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+        @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "question_id", nullable = false)
         var question: Question
 

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/explorer/LikeExplorer.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/explorer/LikeExplorer.kt
@@ -2,15 +2,19 @@ package com.th.plu.domain.domain.like.explorer
 
 import com.th.plu.common.exception.code.ErrorCode
 import com.th.plu.common.exception.model.NotFoundException
+import com.th.plu.domain.domain.answer.Answer
+import com.th.plu.domain.domain.like.Like
 import com.th.plu.domain.domain.like.repository.LikeRepository
+import com.th.plu.domain.domain.member.Member
+import com.th.plu.domain.domain.question.Question
 import org.springframework.stereotype.Component
 
 @Component
 class LikeExplorer(
         private val likeRepository: LikeRepository
 ) {
-    fun findLikeById(id: Long) {
-        likeRepository.findLikeById(id)
-                ?: throw NotFoundException(ErrorCode.NOT_FOUND_LIKE_EXCEPTION, "존재하지 않는 공감(ID: $id) 입니다")
+    fun findLikeByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Like {
+        return likeRepository.findLikeByMemberAndAnswerAndQuestion(member = member, answer = answer, question = question)
+                ?: throw NotFoundException(ErrorCode.NOT_FOUND_LIKE_EXCEPTION, "존재하지 않는 공감 입니다")
     }
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/explorer/LikeExplorer.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/explorer/LikeExplorer.kt
@@ -1,0 +1,16 @@
+package com.th.plu.domain.domain.like.explorer
+
+import com.th.plu.common.exception.code.ErrorCode
+import com.th.plu.common.exception.model.NotFoundException
+import com.th.plu.domain.domain.like.repository.LikeRepository
+import org.springframework.stereotype.Component
+
+@Component
+class LikeExplorer(
+        private val likeRepository: LikeRepository
+) {
+    fun findLikeById(id: Long) {
+        likeRepository.findLikeById(id)
+                ?: throw NotFoundException(ErrorCode.NOT_FOUND_LIKE_EXCEPTION, "존재하지 않는 공감(ID: $id) 입니다")
+    }
+}

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepository.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepository.kt
@@ -1,7 +1,7 @@
 package com.th.plu.domain.domain.like.repository
 
-import com.th.plu.domain.domain.member.Member
+import com.th.plu.domain.domain.like.Like
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface LikeRepository : JpaRepository<Member, Long>, LikeRepositoryCustom {
+interface LikeRepository : JpaRepository<Like, Long>, LikeRepositoryCustom {
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryCustom.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryCustom.kt
@@ -1,8 +1,13 @@
 package com.th.plu.domain.domain.like.repository
 
+import com.th.plu.domain.domain.answer.Answer
 import com.th.plu.domain.domain.like.Like
+import com.th.plu.domain.domain.member.Member
+import com.th.plu.domain.domain.question.Question
 
 interface LikeRepositoryCustom {
 
     fun findLikeById(id: Long): Like?
+
+    fun existByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Boolean
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryCustom.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryCustom.kt
@@ -10,4 +10,6 @@ interface LikeRepositoryCustom {
     fun findLikeById(id: Long): Like?
 
     fun existByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Boolean
+
+    fun findLikeByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Like?
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryImpl.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryImpl.kt
@@ -14,7 +14,7 @@ class LikeRepositoryImpl(private val queryFactory: JPAQueryFactory) : LikeReposi
         return queryFactory
                 .selectFrom(like)
                 .where(like.id.eq(id))
-                .fetchOne();
+                .fetchOne()
     }
 
     override fun existByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Boolean {
@@ -25,6 +25,15 @@ class LikeRepositoryImpl(private val queryFactory: JPAQueryFactory) : LikeReposi
                         like.answer.eq(answer),
                         like.question.eq(question)
                 ).fetchOne() != null
+    }
 
+    override fun findLikeByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Like? {
+        return queryFactory
+                .selectFrom(like)
+                .where(
+                        like.member.eq(member),
+                        like.answer.eq(answer),
+                        like.question.eq(question)
+                ).fetchOne()
     }
 }

--- a/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryImpl.kt
+++ b/plu-domain/src/main/kotlin/com/th/plu/domain/domain/like/repository/LikeRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.th.plu.domain.domain.like.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.th.plu.domain.domain.answer.Answer
 import com.th.plu.domain.domain.like.Like
 import com.th.plu.domain.domain.like.QLike.like
+import com.th.plu.domain.domain.member.Member
+import com.th.plu.domain.domain.question.Question
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -12,5 +15,16 @@ class LikeRepositoryImpl(private val queryFactory: JPAQueryFactory) : LikeReposi
                 .selectFrom(like)
                 .where(like.id.eq(id))
                 .fetchOne();
+    }
+
+    override fun existByMemberAndAnswerAndQuestion(member: Member, answer: Answer, question: Question): Boolean {
+        return queryFactory
+                .selectFrom(like)
+                .where(
+                        like.member.eq(member),
+                        like.answer.eq(answer),
+                        like.question.eq(question)
+                ).fetchOne() != null
+
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #29 

## 🔑 Key Changes

1. 답변 공감 기능
2. 답변 공감 취소 기능

## 📸 Screenshot


## 📢 To Reviewers
- 이미 공감된 답변에 또다시 공감 API를 보내면 Conflict가 발생하도록 구현하였습니다.
- 이미 공감 취소된 답변에 또다시 공감 취소 API를 보내면 NotFound가 발생하도록 구현하였습니다.
- #28 에서 개발한 Like 엔티티가 필요해서 feat/#28 브랜치에서 새로운 브랜치를 뻗어 개발하였습니다 때문에 feat/#28 브랜치의 커밋이 섞여있는데, 이 부분 감안하여 #29가 붙은 커밋에 리뷰 부탁드립니다
- 노션에 에러코드 재정리가 필요해보입니다. 개발 끝나고 정리한번 해야할 것 같습니다

